### PR TITLE
Exclude dependency commons-lang3 since it already exists in Halo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,10 @@ jar {
 
 dependencies {
     implementation 'org.dom4j:dom4j:2.1.3'
-    implementation 'org.apache.commons:commons-text:1.10.0'
+    implementation('org.apache.commons:commons-text:1.10.0') {
+        // Because the transitive dependency already exists in halo.
+        exclude group: 'org.apache.commons', module: 'commons-lang3'
+    }
 
     implementation platform('run.halo.tools.platform:plugin:2.9.0-SNAPSHOT')
     compileOnly 'run.halo.app:api'


### PR DESCRIPTION
This PR reduces artifact size by 23.5%.

Before:

```bash
1.7M Oct 11 23:26 plugin-feed.jar
```

After:

```bash
1.3M Oct 11 23:26 plugin-feed.jar
```

```release-note
缩小 23.5% 插件制品体积
```