### PR TITLE
chore: remove deprecated plugin wrapper

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ dependencies {
         exclude group: 'org.apache.commons', module: 'commons-lang3'
     }
 
-    implementation platform('run.halo.tools.platform:plugin:2.9.0-SNAPSHOT')
+    implementation platform('run.halo.tools.platform:plugin:2.10.0-SNAPSHOT')
     compileOnly 'run.halo.app:api'
 
     testImplementation 'run.halo.app:api'

--- a/src/main/java/run/halo/feed/FeedPlugin.java
+++ b/src/main/java/run/halo/feed/FeedPlugin.java
@@ -1,14 +1,14 @@
 package run.halo.feed;
 
-import org.pf4j.PluginWrapper;
 import org.springframework.stereotype.Component;
 import run.halo.app.plugin.BasePlugin;
+import run.halo.app.plugin.PluginContext;
 
 @Component
 public class FeedPlugin extends BasePlugin {
 
-    public FeedPlugin(PluginWrapper wrapper) {
-        super(wrapper);
+    public FeedPlugin(PluginContext pluginContext) {
+        super(pluginContext);
     }
 
     @Override

--- a/src/main/resources/plugin.yaml
+++ b/src/main/resources/plugin.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   enabled: true
   version: 1.1.1
-  requires: ">=2.7.0"
+  requires: ">=2.10.0"
   author:
     name: Halo
     website: https://github.com/halo-dev


### PR DESCRIPTION
### What this PR does?
移除对已过时的 PluginWrapper 的引用

see also https://github.com/halo-dev/halo/pull/6243

```release-note
None
```