### PR TITLE
feat: 支持添加自定义内容用于follow认证 & 支持封面图 #36

### DIFF
--- a/src/main/java/run/halo/feed/BasicSetting.java
+++ b/src/main/java/run/halo/feed/BasicSetting.java
@@ -16,6 +16,8 @@ public class BasicSetting {
 
     private Integer outputNum = 20;
 
+    private String customContent = "";  // 用户自定义内容，可用于 follow 认证，默认为空
+
 
     enum DescriptionType {
         /**

--- a/src/main/java/run/halo/feed/RSS2.java
+++ b/src/main/java/run/halo/feed/RSS2.java
@@ -5,6 +5,7 @@ import lombok.Data;
 import org.dom4j.Document;
 import org.dom4j.DocumentHelper;
 import org.dom4j.Element;
+import org.apache.commons.lang3.StringUtils;
 
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -21,6 +22,8 @@ public class RSS2 {
     private String description;
 
     private List<Item> items;
+
+    private String customContent;
 
     @Data
     @Builder
@@ -60,6 +63,11 @@ public class RSS2 {
                 itemElement.addElement("pubDate")
                         .addText(item.pubDate.atOffset(ZoneOffset.UTC).format(DateTimeFormatter.RFC_1123_DATE_TIME));
             });
+        }
+
+        // 只有当 customContent 不为空且不为空白字符时才添加
+        if (StringUtils.hasText(customContent)) {
+            channel.addElement("custom").addCDATA(customContent);
         }
 
         return document.asXML();

--- a/src/main/resources/extensions/settings.yaml
+++ b/src/main/resources/extensions/settings.yaml
@@ -32,3 +32,9 @@ spec:
           label: 内容输出条数
           value: 20
           validation: required|number|min:1
+        - $formkit: code
+          name: customContent
+          label: 自定义代码内容
+          placeholder: 在此输入要追加到RSS文件末尾的自定义内容，可用于 follow 认证等
+          value: ""    // 默认值为空
+          language: json


### PR DESCRIPTION
尝试解决 https://github.com/halo-dev/plugin-feed/issues/36

1. 添加自定义内容，追加在最后，用于 follow 订阅认证
<img width="711" alt="image" src="https://github.com/user-attachments/assets/5e4b7eb5-72d1-4114-a811-ae5ba7563c53">

2. 对于封面图无法识别的问题，follow会自动抓取内容的第一个图片作为封面，因此尝试通过meta抓取封面图

<img width="1322" alt="image" src="https://github.com/user-attachments/assets/ca457dbf-d1f5-49f2-a823-eb80ad84b05b">
