### PR TITLE
fix: correct inaccurate descriptions in the extended feed doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ public class RssAutoConfiguration {
     }
 
     @Async
-    @EventListener({MomentUpdatedEvent.class, MomentDeletedEvent.class, ContextClosedEvent.class})
+    @EventListener({MomentUpdatedEvent.class, MomentDeletedEvent.class})
     public void onMomentUpdatedOrDeleted() {
         var rule = CacheClearRule.forExact("/feed/moments/rss.xml");
         var event = RssCacheClearRequested.forRule(this, rule);


### PR DESCRIPTION
### What this PR does?

移除监听 ContextClosedEvent 来清理 RSS 缓存的描述

如果插件 A 监听这个事件来清理 rss 缓存，那么当 feed 更新时会导致插件 A 发生以下错误只能重启 Halo 才能恢复

```shell
java.lang.reflect.UndeclaredThrowableException: Failed to invoke event listener method
HandlerMethod details: 
Bean [run.halo.moments.rss.RssAutoConfiguration$$SpringCGLIB$$0]
Method [public void run.halo.moments.rss.RssAutoConfiguration.onMomentUpdatedOrDeleted()]
Resolved arguments: 
of class "run/halo/feed/RssCacheClearRequested" have different types for the method signature
```

```release-note
None
```