### PR TITLE
feat: add RSS feed for subscribing to post lists by tag slug

### DIFF
--- a/app/src/main/java/run/halo/feed/provider/TagPostRssProvider.java
+++ b/app/src/main/java/run/halo/feed/provider/TagPostRssProvider.java
@@ -1,0 +1,71 @@
+package run.halo.feed.provider;
+
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import run.halo.app.content.PostContentService;
+import run.halo.app.extension.ListResult;
+import run.halo.app.extension.ReactiveExtensionClient;
+import run.halo.app.infra.ExternalLinkProcessor;
+import run.halo.app.infra.ExternalUrlSupplier;
+import run.halo.app.infra.SystemInfoGetter;
+import run.halo.app.plugin.ReactiveSettingFetcher;
+import run.halo.feed.BasicProp;
+import run.halo.feed.RSS2;
+import run.halo.feed.RssRouteItem;
+import run.halo.feed.service.PostService;
+
+@Component
+public class TagPostRssProvider extends AbstractPostRssProvider implements RssRouteItem {
+
+    public TagPostRssProvider(PostService postService, ReactiveExtensionClient client,
+        ExternalLinkProcessor externalLinkProcessor, ReactiveSettingFetcher settingFetcher,
+        PostContentService postContentService, ExternalUrlSupplier externalUrlSupplier,
+        SystemInfoGetter systemInfoGetter) {
+        super(postService, client, externalLinkProcessor, settingFetcher, postContentService,
+            externalUrlSupplier, systemInfoGetter);
+    }
+
+    @Override
+    public Mono<String> pathPattern() {
+        return BasicProp.getBasicProp(settingFetcher)
+            .filter(BasicProp::isEnableCategories)
+            .map(prop -> "/tags/{slug}.xml");
+    }
+
+    @Override
+    @NonNull
+    public String displayName() {
+        return "标签文章订阅";
+    }
+
+    @Override
+    public String description() {
+        return "按标签订阅站点文章";
+    }
+
+    public Mono<RSS2> handler(ServerRequest request) {
+        var slug = request.pathVariable("slug");
+        return super.handler(request)
+            .flatMap(rss2 -> postService.getTagBySlug(slug)
+                .doOnNext(tag -> {
+                    var displayName = tag.getSpec().getDisplayName();
+                    var permalink = tag.getStatusOrDefault().getPermalink();
+                    rss2.setTitle("标签：" + displayName + " - " + rss2.getTitle());
+                    rss2.setLink(externalLinkProcessor.processLink(permalink));
+                })
+                .thenReturn(rss2)
+            );
+    }
+
+    @Override
+    protected Flux<PostWithContent> listPosts(ServerRequest request) {
+        var tagSlug = request.pathVariable("slug");
+        return listPostsByFunc(basicProp ->
+            postService.listPostByTagSlug(basicProp.getOutputNum(), tagSlug)
+                .flatMapIterable(ListResult::getItems)
+        );
+    }
+}

--- a/app/src/main/java/run/halo/feed/service/PostService.java
+++ b/app/src/main/java/run/halo/feed/service/PostService.java
@@ -3,6 +3,7 @@ package run.halo.feed.service;
 import reactor.core.publisher.Mono;
 import run.halo.app.core.extension.content.Category;
 import run.halo.app.core.extension.content.Post;
+import run.halo.app.core.extension.content.Tag;
 import run.halo.app.extension.ListResult;
 
 public interface PostService {
@@ -10,7 +11,11 @@ public interface PostService {
 
     Mono<ListResult<Post>> listPostByCategorySlug(int size, String categorySlug);
 
+    Mono<ListResult<Post>> listPostByTagSlug(int size, String tagSlug);
+
     Mono<ListResult<Post>> listPostByAuthor(int size, String author);
 
     Mono<Category> getCategoryBySlug(String categorySlug);
+
+    Mono<Tag> getTagBySlug(String slug);
 }

--- a/app/src/main/resources/extensions/ext-definition.yaml
+++ b/app/src/main/resources/extensions/ext-definition.yaml
@@ -22,6 +22,16 @@ spec:
 apiVersion: plugin.halo.run/v1alpha1
 kind: ExtensionDefinition
 metadata:
+  name: feed-tag-post-rss-item
+spec:
+  className: run.halo.feed.provider.TagPostRssProvider
+  extensionPointName: feed-rss-route-item
+  displayName: "标签文章订阅"
+  description: "用于生成按照标签订阅文章列表的 RSS 订阅源"
+---
+apiVersion: plugin.halo.run/v1alpha1
+kind: ExtensionDefinition
+metadata:
   name: feed-author-post-rss-item
 spec:
   className: run.halo.feed.provider.AuthorPostRssProvider


### PR DESCRIPTION
### What this PR does?
支持根据标签别名订阅文章列表

示例： http://localhost:8090/feed/tags/halo.xml

Fixes #38

```release-note
支持根据标签别名订阅文章列表
```