### PR TITLE
fix: replace author tag with dc:creator to specify the author

### DIFF
--- a/app/src/main/java/run/halo/feed/RssXmlBuilder.java
+++ b/app/src/main/java/run/halo/feed/RssXmlBuilder.java
@@ -64,6 +64,7 @@ public class RssXmlBuilder {
 
         Element root = DocumentHelper.createElement("rss");
         root.addAttribute("version", "2.0");
+        root.addNamespace("dc", "http://purl.org/dc/elements/1.1/");
         root.addNamespace("media", "http://search.yahoo.com/mrss/");
         document.setRootElement(root);
 
@@ -167,7 +168,9 @@ public class RssXmlBuilder {
             .addText(item.getGuid());
 
         if (StringUtils.isNotBlank(item.getAuthor())) {
-            itemElement.addElement("author").addText(item.getAuthor());
+            // https://www.rssboard.org/rss-validator/docs/error/InvalidContact.html
+            itemElement.addElement("dc:creator")
+                .addText(item.getAuthor());
         }
 
         if (StringUtils.isNotBlank(item.getEnclosureUrl())) {

--- a/app/src/test/java/run/halo/feed/RSS2Test.java
+++ b/app/src/test/java/run/halo/feed/RSS2Test.java
@@ -45,7 +45,8 @@ class RSS2Test {
         // language=xml
         var expected = """
             <?xml version="1.0" encoding="UTF-8"?>
-            <rss xmlns:media="http://search.yahoo.com/mrss/" version="2.0">
+            <rss xmlns:dc="http://purl.org/dc/elements/1.1/"
+             xmlns:media="http://search.yahoo.com/mrss/" version="2.0">
             	<channel>
             		<title>title</title>
             		<link>link</link>
@@ -109,7 +110,7 @@ class RSS2Test {
         // language=xml
         var expected = """
             <?xml version="1.0" encoding="UTF-8"?>
-             <rss
+             <rss xmlns:dc="http://purl.org/dc/elements/1.1/"
                 xmlns:media="http://search.yahoo.com/mrss/" version="2.0">
                 <channel>
                     <title>title</title>
@@ -161,7 +162,8 @@ class RSS2Test {
         // language=xml
         var expected = """
             <?xml version="1.0" encoding="UTF-8"?>
-            <rss xmlns:media="http://search.yahoo.com/mrss/" version="2.0">
+            <rss xmlns:dc="http://purl.org/dc/elements/1.1/"
+            xmlns:media="http://search.yahoo.com/mrss/" version="2.0">
             	<channel>
             		<title>title</title>
             		<link>link</link>


### PR DESCRIPTION
### What this PR does?
使用 `dc:creator` 标签代替 `author` 来注名作者

参考：https://www.rssboard.org/rss-validator/docs/error/InvalidContact.html

```release-note
使用 `dc:creator` 标签代替 `author` 来注名作者
```