### PR TITLE
Fix the pending problem when requesting RSS endpoint

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,7 +15,7 @@ jar {
 dependencies {
     implementation project(':api')
     compileOnly 'run.halo.app:api'
-    implementation 'org.dom4j:dom4j:2.1.3'
+    implementation 'org.dom4j:dom4j:2.1.4'
     implementation('org.apache.commons:commons-text:1.10.0') {
         // Because the transitive dependency already exists in halo.
         exclude group: 'org.apache.commons', module: 'commons-lang3'
@@ -23,6 +23,7 @@ dependencies {
 
     testImplementation 'run.halo.app:api'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'io.projectreactor:reactor-test'
 }
 
 tasks.register('copyUI', Copy) {

--- a/app/src/main/java/run/halo/feed/provider/AbstractPostRssProvider.java
+++ b/app/src/main/java/run/halo/feed/provider/AbstractPostRssProvider.java
@@ -126,8 +126,7 @@ public abstract class AbstractPostRssProvider {
 
     protected Mono<User> fetchUser(String username) {
         return client.fetch(User.class, username)
-            .switchIfEmpty(Mono.error(new ServerWebInputException("User not found")))
-            .subscribeOn(Schedulers.boundedElastic());
+            .switchIfEmpty(Mono.error(new ServerWebInputException("User not found")));
     }
 
     private Flux<String> fetchCategoryDisplayName(List<String> categoryNames) {
@@ -137,8 +136,7 @@ public abstract class AbstractPostRssProvider {
         return client.listAll(Category.class, ListOptions.builder()
                 .fieldQuery(QueryFactory.in("metadata.name", categoryNames))
                 .build(), ExtensionUtil.defaultSort())
-            .map(category -> category.getSpec().getDisplayName())
-            .subscribeOn(Schedulers.boundedElastic());
+            .map(category -> category.getSpec().getDisplayName());
     }
 
     @Data

--- a/app/src/test/java/run/halo/feed/RSS2Test.java
+++ b/app/src/test/java/run/halo/feed/RSS2Test.java
@@ -6,6 +6,7 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
+import reactor.test.StepVerifier;
 
 class RSS2Test {
 
@@ -80,7 +81,10 @@ class RSS2Test {
             	</channel>
             </rss>
             """.formatted(lastBuildDate);
-        assertThat(rssXml).isEqualToIgnoringWhitespace(expected);
+
+        StepVerifier.create(rssXml)
+            .assertNext(xml -> assertThat(xml).isEqualToIgnoringWhitespace(expected))
+            .verifyComplete();
     }
 
     @Test
@@ -132,7 +136,9 @@ class RSS2Test {
                 </channel>
              </rss>
             """.formatted(lastBuildDate);
-        assertThat(rssXml).isEqualToIgnoringWhitespace(expected);
+        StepVerifier.create(rssXml)
+            .assertNext(xml -> assertThat(xml).isEqualToIgnoringWhitespace(expected))
+            .verifyComplete();
     }
 
     @Test
@@ -188,6 +194,8 @@ class RSS2Test {
             	</channel>
             </rss>
             """.formatted(lastBuildDate);
-        assertThat(rssXml).isEqualToIgnoringWhitespace(expected);
+        StepVerifier.create(rssXml)
+            .assertNext(xml -> assertThat(xml).isEqualToIgnoringWhitespace(expected))
+            .verifyComplete();
     }
 }

--- a/app/src/test/java/run/halo/feed/RssXmlBuilderTest.java
+++ b/app/src/test/java/run/halo/feed/RssXmlBuilderTest.java
@@ -1,0 +1,28 @@
+package run.halo.feed;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static run.halo.feed.RssXmlBuilder.parseLengthOfContentRange;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class RssXmlBuilderTest {
+
+    static Stream<Arguments> testParseLengthOfContentRange() {
+        return Stream.of(
+            arguments("bytes 0-0/123", 123L),
+            arguments("bytes */567", 567L),
+            arguments("bytes 0-0", null),
+            arguments("bytes 0-0/*", null)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void testParseLengthOfContentRange(String contentRange, Long expected) {
+        assertEquals(expected, parseLengthOfContentRange(contentRange));
+    }
+}

--- a/app/src/test/resources/logback.xml
+++ b/app/src/test/resources/logback.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <include resource="org/springframework/boot/logging/logback/console-appender.xml" />
+    <root level="INFO">
+        <appender-ref ref="CONSOLE" />
+    </root>
+    <logger name="run.halo.feed" level="DEBUG"/>
+</configuration>


### PR DESCRIPTION
This PR fixes the problem and refine the logic of getting file bytes.

After upgrading to Halo 2.20.16, requesting RSS endpoint may cause entirely pending issue. Please see the following concrete logs:

```java
2025-03-11T01:04:39.536+08:00 ERROR 7 --- [loomBoundedElastic-361] a.w.r.e.AbstractErrorWebExceptionHandler : [756c052a-61]  500 Server Error for HTTP GET "/rss.xml"

com.google.common.util.concurrent.UncheckedExecutionException: reactor.core.Exceptions$ReactiveException: java.lang.InterruptedException
	at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2085) ~[guava-33.3.1-jre.jar:na]
	Suppressed: reactor.core.publisher.FluxOnAssembly$OnAssemblyException: 
Error has been observed at the following site(s):
	*__checkpoint ⇢ run.halo.app.security.InitializeRedirectionWebFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ run.halo.app.infra.webfilter.LocaleChangeWebFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ run.halo.app.security.device.DeviceSessionFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ run.halo.cache.page.PageCacheWebFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ SecurityWebFilterChainProxy [DefaultWebFilterChain]
	*__checkpoint ⇢ AuthorizationWebFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ ExceptionTranslationWebFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ LogoutWebFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ ServerRequestCacheWebFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ SecurityContextServerWebExchangeWebFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ SecurityWebFilterChainProxy [DefaultWebFilterChain]
	*__checkpoint ⇢ AnonymousAuthenticationWebFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ SecurityWebFilterChainProxy [DefaultWebFilterChain]
	*__checkpoint ⇢ run.halo.social.login.security.SocialAuthenticatorFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ SecurityWebFilterChainProxy [DefaultWebFilterChain]
	*__checkpoint ⇢ AuthenticationWebFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ AuthenticationWebFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ AuthenticationWebFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ MapOAuth2AuthenticationFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ AuthenticationWebFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ SecurityWebFilterChainProxy [DefaultWebFilterChain]
	*__checkpoint ⇢  [DefaultWebFilterChain]
	*__checkpoint ⇢ run.halo.social.login.security.SocialAuthorizationRequestRedirectWebFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ SecurityWebFilterChainProxy [DefaultWebFilterChain]
	*__checkpoint ⇢ ReactorContextWebFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ CsrfWebFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ CorsWebFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ HttpHeaderWriterWebFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ SecurityWebFilterChainProxy [DefaultWebFilterChain]
	*__checkpoint ⇢ ServerWebExchangeReactorContextWebFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ org.springframework.security.web.server.WebFilterChainProxy [DefaultWebFilterChain]
	*__checkpoint ⇢ run.halo.seo.tools.AdvancedRedirectWebFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ run.halo.moments.rss.OldRssRouteRedirectionFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ run.halo.comment.widget.captcha.CommentCaptchaFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ run.halo.seo.tools.CrawlRecordFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ cc.ryanc.staticpages.endpoint.RewriteOnNotFoundFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ run.halo.app.infra.webfilter.AdditionalWebFilterChainProxy [DefaultWebFilterChain]
	*__checkpoint ⇢ org.springframework.web.filter.reactive.ServerWebExchangeContextFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ HTTP GET "/rss.xml" [ExceptionHandlingWebHandler]
Original Stack Trace:
		at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2085) ~[guava-33.3.1-jre.jar:na]
		at com.google.common.cache.LocalCache.get(LocalCache.java:4017) ~[guava-33.3.1-jre.jar:na]
		at com.google.common.cache.LocalCache$LocalManualCache.get(LocalCache.java:4898) ~[guava-33.3.1-jre.jar:na]
		at run.halo.feed.RssCacheManager.lambda$get$2(RssCacheManager.java:29) ~[na:na]
		at reactor.core.publisher.MonoCallable$MonoCallableSubscription.request(MonoCallable.java:137) ~[reactor-core-3.7.3.jar:3.7.3]
		at reactor.core.publisher.MonoCacheTime$CoordinatorSubscriber.onSubscribe(MonoCacheTime.java:293) ~[reactor-core-3.7.3.jar:3.7.3]
		at reactor.core.publisher.MonoCallable.subscribe(MonoCallable.java:48) ~[reactor-core-3.7.3.jar:3.7.3]
		at reactor.core.publisher.MonoCacheTime.subscribeOrReturn(MonoCacheTime.java:143) ~[reactor-core-3.7.3.jar:3.7.3]
		at reactor.core.publisher.Mono.subscribe(Mono.java:4560) ~[reactor-core-3.7.3.jar:3.7.3]
		at reactor.core.publisher.MonoSubscribeOn$SubscribeOnSubscriber.run(MonoSubscribeOn.java:126) ~[reactor-core-3.7.3.jar:3.7.3]
		at reactor.core.scheduler.BoundedElasticThreadPerTaskScheduler$SchedulerTask.run(BoundedElasticThreadPerTaskScheduler.java:1013) ~[reactor-core-3.7.3.jar:3.7.3]
		at java.base/java.lang.VirtualThread.run(Unknown Source) ~[na:na]
Caused by: reactor.core.Exceptions$ReactiveException: java.lang.InterruptedException
	at reactor.core.Exceptions$ReactiveException.fillInStackTrace(Exceptions.java:736) ~[reactor-core-3.7.3.jar:3.7.3]
	at java.base/java.lang.Throwable.<init>(Unknown Source) ~[na:na]
	at java.base/java.lang.Throwable.<init>(Unknown Source) ~[na:na]
	at java.base/java.lang.Exception.<init>(Unknown Source) ~[na:na]
	at java.base/java.lang.RuntimeException.<init>(Unknown Source) ~[na:na]
	at reactor.core.Exceptions$ReactiveException.<init>(Exceptions.java:726) ~[reactor-core-3.7.3.jar:3.7.3]
	at reactor.core.Exceptions.propagate(Exceptions.java:410) ~[reactor-core-3.7.3.jar:3.7.3]
	at reactor.core.publisher.BlockingSingleSubscriber.blockingGet(BlockingSingleSubscriber.java:96) ~[reactor-core-3.7.3.jar:3.7.3]
	at reactor.core.publisher.Mono.block(Mono.java:1779) ~[reactor-core-3.7.3.jar:3.7.3]
	at run.halo.feed.RssCacheManager.lambda$get$1(RssCacheManager.java:32) ~[na:na]
	at com.google.common.cache.LocalCache$LocalManualCache$1.load(LocalCache.java:4903) ~[guava-33.3.1-jre.jar:na]
	at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3574) ~[guava-33.3.1-jre.jar:na]
	at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2316) ~[guava-33.3.1-jre.jar:na]
	at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2189) ~[guava-33.3.1-jre.jar:na]
	at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2079) ~[guava-33.3.1-jre.jar:na]
	at com.google.common.cache.LocalCache.get(LocalCache.java:4017) ~[guava-33.3.1-jre.jar:na]
	at com.google.common.cache.LocalCache$LocalManualCache.get(LocalCache.java:4898) ~[guava-33.3.1-jre.jar:na]
	at run.halo.feed.RssCacheManager.lambda$get$2(RssCacheManager.java:29) ~[na:na]
	at reactor.core.publisher.MonoCallable$MonoCallableSubscription.request(MonoCallable.java:137) ~[reactor-core-3.7.3.jar:3.7.3]
	at reactor.core.publisher.MonoCacheTime$CoordinatorSubscriber.onSubscribe(MonoCacheTime.java:293) ~[reactor-core-3.7.3.jar:3.7.3]
	at reactor.core.publisher.MonoCallable.subscribe(MonoCallable.java:48) ~[reactor-core-3.7.3.jar:3.7.3]
	at reactor.core.publisher.MonoCacheTime.subscribeOrReturn(MonoCacheTime.java:143) ~[reactor-core-3.7.3.jar:3.7.3]
	at reactor.core.publisher.Mono.subscribe(Mono.java:4560) ~[reactor-core-3.7.3.jar:3.7.3]
	at reactor.core.publisher.MonoSubscribeOn$SubscribeOnSubscriber.run(MonoSubscribeOn.java:126) ~[reactor-core-3.7.3.jar:3.7.3]
	at reactor.core.scheduler.BoundedElasticThreadPerTaskScheduler$SchedulerTask.run(BoundedElasticThreadPerTaskScheduler.java:1013) ~[reactor-core-3.7.3.jar:3.7.3]
	at java.base/java.lang.VirtualThread.run(Unknown Source) ~[na:na]
Caused by: java.lang.InterruptedException: null
	at java.base/java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireSharedInterruptibly(Unknown Source) ~[na:na]
	at java.base/java.util.concurrent.CountDownLatch.await(Unknown Source) ~[na:na]
	at reactor.core.publisher.BlockingSingleSubscriber.blockingGet(BlockingSingleSubscriber.java:91) ~[reactor-core-3.7.3.jar:3.7.3]
	... 18 common frames omitted
```

/kind bug

```release-note
None
```
